### PR TITLE
redesign: 公開ページのUIを刷新(ビールの黄色はアクセントに)

### DIFF
--- a/components/common/Navbar.js
+++ b/components/common/Navbar.js
@@ -17,28 +17,22 @@ const Navbar = () => {
   };
 
   return (
-    <AppBar position="static" style={{ backgroundColor: 'white' }}>
+    <AppBar position="static" sx={{ bgcolor: 'background.paper' }}>
       <Toolbar>
-        <IconButton href="/" edge="start" color="inherit" aria-label="menu" onClick={handleMenuToggle}>
-          <SportsBarIcon style={{ color: 'black' }} />
+        <IconButton href="/" edge="start" aria-label="menu" onClick={handleMenuToggle}>
+          <SportsBarIcon sx={{ color: 'primary.main' }} />
         </IconButton>
-        <Typography variant="h6" style={{ flexGrow: 1, color: 'black' }}>
+        <Typography variant="h6" sx={{ flexGrow: 1, color: 'text.primary', fontWeight: 700 }}>
           せんべろCheers
         </Typography>
-        
+
         {/* レストラン追加ボタン */}
         <Button
           href="/restaurants/new"  // 新規追加ページへのリンク
-          color="inherit"
+          variant="outlined"
+          color="secondary"
           startIcon={<AddIcon />}
-          style={{ 
-            color: 'black',
-            marginRight: '1rem',
-            backgroundColor: '#f5f5f5',
-            '&:hover': {
-              backgroundColor: '#e0e0e0'
-            }
-          }}
+          size="small"
         >
           店舗を追加
         </Button>

--- a/components/restaurant/RestaurantCard.jsx
+++ b/components/restaurant/RestaurantCard.jsx
@@ -17,53 +17,63 @@ export const RestaurantCard = ({ restaurant, onClick }) => {
     <Card
       className="flex flex-row overflow-hidden cursor-pointer"
       onClick={() => onClick(restaurant.restaurant_id)}
-      sx={{ position: 'relative'}}
+      sx={{
+        position: 'relative',
+        transition: 'box-shadow 0.15s ease, transform 0.15s ease',
+        '&:hover': {
+          boxShadow: '0 6px 20px rgba(42, 32, 25, 0.14)',
+          transform: 'translateY(-1px)',
+        },
+      }}
     >
       {/* Restaurant Image */}
-      <Box className="w-32" sx={{ position: 'relative', width: 128, height: 200, flexShrink: 0 }}>
+      <Box sx={{ position: 'relative', width: 112, height: 144, flexShrink: 0 }}>
         <Image
           src={restaurant.restaurant_image || '/default-restaurant-image.jpg'}
           alt={restaurant.name}
           fill
-          sizes="128px"
+          sizes="112px"
           style={{ objectFit: 'cover' }}
         />
       </Box>
 
       {/* Restaurant Details */}
-      <Box className="flex-1">
-      <CardContent>
-        <Typography variant="h6" component="div">
-          {restaurant.name}
-        </Typography>
-        <Box sx={{ marginTop: 1 }}>
-          <Box display="flex" alignItems="center">
-            <AccessTime sx={{ marginRight: 1 }} />
+      <Box className="flex-1" sx={{ minWidth: 0 }}>
+        <CardContent sx={{ py: 1.5, pr: 8 }}>
+          <Typography
+            variant="subtitle1"
+            component="div"
+            sx={{ fontWeight: 700, lineHeight: 1.3, mb: 1 }}
+          >
+            {restaurant.name}
+          </Typography>
+          <Box display="flex" alignItems="center" sx={{ color: 'text.secondary' }}>
+            <AccessTime sx={{ mr: 0.75, fontSize: 18 }} />
             <Typography variant="body2">
-              営業時間：{getTodayOperatingHours(restaurant.operating_hours)}
+              {getTodayOperatingHours(restaurant.operating_hours)}
             </Typography>
           </Box>
           {restaurant.distance != null && (
-            <Box display="flex" alignItems="center" mt={2}>
-              <DirectionsRun sx={{ marginRight: 1 }} />
+            <Box display="flex" alignItems="center" mt={0.5} sx={{ color: 'text.secondary' }}>
+              <DirectionsRun sx={{ mr: 0.75, fontSize: 18 }} />
               <Typography variant="body2">
-                距離：{restaurant.distance.toFixed(2)} km
+                {restaurant.distance.toFixed(2)} km
               </Typography>
             </Box>
           )}
-        </Box>
-      </CardContent>
+        </CardContent>
 
         {/* Map Button */}
         <Fab
           color="primary"
+          size="small"
           href={mapSearchUrl}
           target="_blank"
           rel="noopener noreferrer"
-          sx={{ position: 'absolute', bottom: 16, right: 16 }}
+          sx={{ position: 'absolute', bottom: 12, right: 12, boxShadow: 'none' }}
           onClick={handleMapClick}
         >
-          <Place />
+          <Place fontSize="small" />
         </Fab>
       </Box>
     </Card>

--- a/components/restaurant/RestaurantDetail.js
+++ b/components/restaurant/RestaurantDetail.js
@@ -21,7 +21,7 @@ const RestaurantDetail = ({ restaurant }) => {
   };
 
   return (
-    <Container maxWidth="md" sx={{ py: 4 }}>
+    <Container maxWidth="md" sx={{ py: { xs: 2, sm: 4 }, px: { xs: 1.5, sm: 3 } }}>
       <Card>
         <Box sx={{ position: 'relative' }}>
           <CardContent>

--- a/components/restaurant/RestaurantFeatures.js
+++ b/components/restaurant/RestaurantFeatures.js
@@ -15,10 +15,11 @@ import {
   Typography,
 } from '@mui/material';
 import React from 'react';
+import { palette } from '@/styles/theme';
 
 const FeatureItem = ({ icon: Icon, label, isActive, description }) => (
   <Box sx={{ display: 'flex', alignItems: 'center', m: 2 }}>
-    <Box sx={{ mr: 2, color: isActive ? '#ffc107' : 'action.disabled' }}>
+    <Box sx={{ mr: 2, color: isActive ? 'primary.main' : 'action.disabled' }}>
       <Icon fontSize="large" />
     </Box>
     <Box sx={{ flexGrow: 1 }}>
@@ -35,12 +36,34 @@ const FeatureItem = ({ icon: Icon, label, isActive, description }) => (
 );
 
 const PriceItem = ({ icon: Icon, label, price }) => (
-  <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flexDirection: 'column', m: 2 }}>
-    <Icon fontSize="large" sx={{ color: '#ffc107', mb: 1 }} />
-    <Typography variant="subtitle1" component="div">
+  <Box
+    sx={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexDirection: 'column',
+      p: 2,
+    }}
+  >
+    <Box
+      sx={{
+        bgcolor: palette.amberSoft,
+        color: 'primary.main',
+        borderRadius: '50%',
+        width: 56,
+        height: 56,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        mb: 1,
+      }}
+    >
+      <Icon fontSize="medium" />
+    </Box>
+    <Typography variant="body2" color="text.secondary">
       {label}
     </Typography>
-    <Typography variant="h6" component="div" sx={{ mt: 1 }}>
+    <Typography variant="h6" component="div" sx={{ mt: 0.5, fontWeight: 700 }}>
       ¥{price}
     </Typography>
   </Box>

--- a/components/restaurant/RestaurantList.tsx
+++ b/components/restaurant/RestaurantList.tsx
@@ -30,8 +30,8 @@ export const RestaurantList: React.FC<RestaurantListProps> = ({ restaurants }) =
   }
 
   return (
-    <Container sx={{ p: 0 }}>
-      <Stack spacing={1} sx={{ pb: 5 }}>
+    <Container maxWidth="sm" sx={{ px: { xs: 1.5, sm: 2 }, pt: 2 }}>
+      <Stack spacing={1.5} sx={{ pb: 5 }}>
         {restaurants.map((restaurant) => (
           <RestaurantCard
             key={restaurant.restaurant_id}

--- a/components/restaurant/SearchForm.js
+++ b/components/restaurant/SearchForm.js
@@ -141,115 +141,129 @@ const SearchForm = () => {
   };
 
   return (
-    <Container fixed>
-      <Typography
-        align="center"
-        variant="h5"
+    <Container maxWidth="sm" sx={{ pt: isMobile ? 6 : 10, pb: 8 }}>
+      <Box
         sx={{
-          color: "white",
-          margin: "48px 0px 24px 0px",
-          fontSize: isMobile ? "20px" : "24px",
+          textAlign: 'center',
+          px: { xs: 1, sm: 0 },
         }}
       >
-        せんべろ好きのための検索サイト
-      </Typography>
-      <Box
-        display="flex"
-        flexDirection={isMobile ? "column" : "row"}
-        justifyContent="center"
-        alignItems="center"
-      >
-        <SportsBarRoundedIcon style={{ fontSize: 80, color: "white" }} />
-        <Typography
-          variant="h2"
+        <Box
           sx={{
-            color: "white",
-            fontSize: isMobile ? "28px" : "48px",
-            marginLeft: isMobile ? "0px" : "10px",
-            marginTop: isMobile ? "10px" : "0px",
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 1,
+            px: 2,
+            py: 0.5,
+            mb: 3,
+            borderRadius: 999,
+            bgcolor: 'primary.main',
+            color: 'primary.contrastText',
           }}
         >
-          せんべろCheers
+          <Typography variant="body2" sx={{ fontWeight: 700, letterSpacing: 0.5 }}>
+            せんべろ好きのための検索サイト
+          </Typography>
+        </Box>
+
+        <Box
+          display="flex"
+          flexDirection={isMobile ? 'column' : 'row'}
+          justifyContent="center"
+          alignItems="center"
+          gap={isMobile ? 1 : 2}
+        >
+          <SportsBarRoundedIcon sx={{ fontSize: isMobile ? 56 : 72, color: 'primary.main' }} />
+          <Typography
+            variant="h2"
+            sx={{
+              color: 'text.primary',
+              fontWeight: 900,
+              fontSize: isMobile ? '30px' : '48px',
+            }}
+          >
+            せんべろCheers
+          </Typography>
+        </Box>
+
+        <Typography
+          variant="h5"
+          sx={{
+            color: 'text.primary',
+            fontWeight: 700,
+            mt: 6,
+            mb: 2,
+            fontSize: isMobile ? '19px' : '26px',
+          }}
+        >
+          イマココ検索とは？
+        </Typography>
+        <Typography
+          sx={{
+            color: 'text.secondary',
+            fontSize: isMobile ? '14px' : '16px',
+            lineHeight: 1.9,
+          }}
+        >
+          次のお店はどこにしようか？
+          <br />
+          お店探しもはしご酒の醍醐味。
+          <br />
+          そんなあなたへ送るはしご酒専用検索機能。
+          <br />
+          「イマ」営業中の居酒屋を「ココ」から近い順に表示します。
+          <br />
+          <br />
+          新しいお店との出会いに乾杯。
         </Typography>
       </Box>
-      <Typography
-        align="center"
-        variant="h4"
-        sx={{
-          color: "white",
-          margin: "60px 0px 12px 0px",
-          fontSize: isMobile ? "20px" : "32px",
-        }}
-      >
-        イマココ検索とは？
-      </Typography>
-      <Typography
-        align="center"
-        sx={{
-          color: "white",
-          fontSize: isMobile ? "14px" : "18px",
-          margin: "0px 0px 48px 0px",
-        }}
-      >
-        次のお店はどこにしようか？
-        <br />
-        お店探しもはしご酒の醍醐味
-        <br />
-        そんなあなたへ送るはしご酒専用検索機能
-        <br />
-        「イマ」営業中の居酒屋を
-        <br />
-        「ココ」から近い順に表示します。
-        <br />
-        <br />
-        新しいお店との出会いに乾杯
-      </Typography>
+
       <Box
         sx={{
-          backgroundColor: "lightyellow",
-          border: "1px solid yellow",
-          padding: "16px",
-          marginTop: "20px",
-          marginBottom: "20px",
-          borderRadius: "8px",
+          bgcolor: 'background.paper',
+          border: '1px solid',
+          borderColor: 'primary.main',
+          borderRadius: 3,
+          px: 2,
+          py: 1.5,
+          mt: 4,
+          mb: 4,
         }}
       >
         <Typography
           align="center"
           sx={{
-            fontSize: isMobile ? "12px" : "16px",
+            color: 'text.secondary',
+            fontSize: isMobile ? '12px' : '14px',
           }}
         >
           ※このアプリは位置情報を使用します。機能を利用する際には位置情報の使用許可が必要になります。
         </Typography>
       </Box>
+
       <Box
         display="flex"
+        flexDirection={isMobile ? 'column' : 'row'}
         justifyContent="center"
-        sx={{ marginTop: "20px" }}
+        gap={1.5}
       >
         <Button
           variant="contained"
           color="primary"
           onClick={handleSearch}
-          sx={{
-            fontSize: isMobile ? "14px" : "16px",
-            padding: isMobile ? "8px 16px" : "12px 24px",
-            borderRadius: "8px",
-            marginRight: "10px",
-          }}
+          fullWidth={isMobile}
+          size="large"
+          sx={{ px: 4 }}
         >
           イマココ検索
         </Button>
         <Button
           variant="outlined"
-          color="primary"
+          color="secondary"
           onClick={handleFeatureDialogOpen}
-          sx={{
-            fontSize: isMobile ? "14px" : "16px",
-            padding: isMobile ? "8px 16px" : "12px 24px",
-            borderRadius: "8px",
-          }}
+          fullWidth={isMobile}
+          size="large"
+          sx={{ px: 4 }}
         >
           特徴から検索
         </Button>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,22 @@
+import CssBaseline from '@mui/material/CssBaseline';
+import { ThemeProvider } from '@mui/material/styles';
 import { SessionProvider } from 'next-auth/react';
 import { AppProps } from 'next/app';
+import { Noto_Sans_JP } from 'next/font/google';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import Script from 'next/script';
 import { useEffect } from 'react';
 import * as gtag from '../lib/gtag'; // gtagモジュールのインポートを確認してください
+import theme from '../styles/theme';
 import { trackPageview } from '../lib/track';
+
+const notoSansJP = Noto_Sans_JP({
+  subsets: ['latin'],
+  weight: ['400', '500', '700', '900'],
+  variable: '--font-sans',
+  display: 'swap',
+});
 
 export default function App({ Component, pageProps: { session, ...pageProps } }: AppProps) {
   const router = useRouter();
@@ -50,9 +61,14 @@ export default function App({ Component, pageProps: { session, ...pageProps } }:
           `,
         }}
       />
-      <SessionProvider session={session}>
-        <Component {...pageProps} />
-      </SessionProvider>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <div className={notoSansJP.variable}>
+          <SessionProvider session={session}>
+            <Component {...pageProps} />
+          </SessionProvider>
+        </div>
+      </ThemeProvider>
     </>
   );
 }

--- a/styles/HomePage.module.css
+++ b/styles/HomePage.module.css
@@ -1,4 +1,4 @@
 .container {
   min-height: 100vh;
-  background-color: rgb(255, 201, 37);
+  background-color: #fbf6ec;
 }

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,0 +1,77 @@
+import { createTheme } from '@mui/material/styles';
+
+// ビール・せんべろのイメージを残しつつ、全面ベタ塗りではなく
+// アクセントカラーとして落ち着かせたパレット。
+export const palette = {
+  cream: '#FBF6EC',
+  paper: '#FFFFFF',
+  ink: '#2A2019',
+  inkSoft: '#6B5F55',
+  amber: '#DDA02A',
+  amberDark: '#A8721B',
+  amberSoft: '#F3E4C4',
+};
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: palette.amber,
+      dark: palette.amberDark,
+      contrastText: palette.ink,
+    },
+    secondary: {
+      main: palette.ink,
+    },
+    background: {
+      default: palette.cream,
+      paper: palette.paper,
+    },
+    text: {
+      primary: palette.ink,
+      secondary: palette.inkSoft,
+    },
+  },
+  shape: {
+    borderRadius: 14,
+  },
+  typography: {
+    fontFamily: 'var(--font-sans), "Hiragino Sans", "Yu Gothic", sans-serif',
+    h2: { fontWeight: 800 },
+    h4: { fontWeight: 700 },
+    h5: { fontWeight: 700 },
+    h6: { fontWeight: 700 },
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+          fontWeight: 700,
+        },
+        containedPrimary: {
+          color: palette.ink,
+          boxShadow: 'none',
+          '&:hover': {
+            boxShadow: 'none',
+          },
+        },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          boxShadow: '0 2px 12px rgba(42, 32, 25, 0.08)',
+        },
+      },
+    },
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          boxShadow: '0 1px 0 rgba(42, 32, 25, 0.08)',
+        },
+      },
+    },
+  },
+});
+
+export default theme;


### PR DESCRIPTION
背景をベタ塗りの黄色(rgb(255,201,37))から、白/クリーム基調+
アクセントとしての琥珀色(amber)に変更。MUIのThemeProviderが
どこにも設定されておらずボタン等がMUIデフォルトの青のままだった
ため、専用テーマ(styles/theme.ts)を作成してpages/_app.tsxに適用。
Noto Sans JPフォントも導入。

- pages/_app.tsx: ThemeProvider・CssBaseline・Webフォントを追加
- styles/theme.ts: カラーパレット・タイポグラフィ・コンポーネント スタイルを定義(黄色は主要アクション・アクティブ状態のアクセント としてのみ使用)
- components/restaurant/SearchForm.js: トップページのヒーロー部分を 白文字べた塗りから、バッジ・アイコン・ボタンにアクセントカラーを 使うレイアウトに刷新
- components/restaurant/RestaurantCard.jsx: カードの余白・タイポ グラフィ・ホバー効果を調整
- components/restaurant/RestaurantFeatures.js: ハードコードされていた #ffc107 をテーマのprimary色に統一、料金アイコンを円形バッジ化
- components/common/Navbar.js: 配色をテーマに統一

対象は公開ページ(トップ・検索・店舗詳細)のみで、管理画面
(app/admin配下、独自のMUIテーマ)は変更していない。

PC/モバイル双方でスクリーンショットにより見た目を確認済み。