### PR TITLE
検索結果での絞り込みチップとせんべろ属性タグ・徒歩時間表示

### DIFF
--- a/components/restaurant/RestaurantCard.jsx
+++ b/components/restaurant/RestaurantCard.jsx
@@ -1,10 +1,14 @@
 import { AccessTime, DirectionsRun, Place } from "@mui/icons-material";
-import { Box, Card, CardContent, Fab, Typography } from '@mui/material';
+import { Box, Card, CardContent, Chip, Fab, Typography } from '@mui/material';
 import Image from 'next/image';
+import { palette } from '../../styles/theme';
 import { getTodayOperatingHours } from '../../utils/dateUtils';
+import { FEATURE_TAGS, walkMinutes } from '../../utils/features';
 
 
 export const RestaurantCard = ({ restaurant, onClick }) => {
+  const activeTags = FEATURE_TAGS.filter((tag) => restaurant[tag.key]);
+
   const handleMapClick = (e) => {
     e.stopPropagation();
   };
@@ -27,7 +31,7 @@ export const RestaurantCard = ({ restaurant, onClick }) => {
       }}
     >
       {/* Restaurant Image */}
-      <Box sx={{ position: 'relative', width: 112, height: 144, flexShrink: 0 }}>
+      <Box sx={{ position: 'relative', width: 112, minHeight: 144, flexShrink: 0, alignSelf: 'stretch' }}>
         <Image
           src={restaurant.restaurant_image || '/default-restaurant-image.jpg'}
           alt={restaurant.name}
@@ -57,8 +61,26 @@ export const RestaurantCard = ({ restaurant, onClick }) => {
             <Box display="flex" alignItems="center" mt={0.5} sx={{ color: 'text.secondary' }}>
               <DirectionsRun sx={{ mr: 0.75, fontSize: 18 }} />
               <Typography variant="body2">
-                {restaurant.distance.toFixed(2)} km
+                徒歩{walkMinutes(restaurant.distance)}分（{restaurant.distance.toFixed(1)}km）
               </Typography>
+            </Box>
+          )}
+          {activeTags.length > 0 && (
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
+              {activeTags.map((tag) => (
+                <Chip
+                  key={tag.key}
+                  label={tag.label}
+                  size="small"
+                  sx={{
+                    bgcolor: palette.amberSoft,
+                    color: 'text.primary',
+                    fontWeight: 700,
+                    fontSize: '0.7rem',
+                    height: 22,
+                  }}
+                />
+              ))}
             </Box>
           )}
         </CardContent>

--- a/components/restaurant/SearchFilterChips.tsx
+++ b/components/restaurant/SearchFilterChips.tsx
@@ -1,0 +1,69 @@
+import { FEATURE_TAGS } from '@/utils/features';
+import { Box, Chip, Container } from '@mui/material';
+import { useRouter } from 'next/router';
+
+// 検索結果画面の上部で特徴の絞り込みをその場で切り替えるチップ列。
+// チップのON/OFFでURLクエリのfeaturesを書き換えると、
+// useRestaurantSearchがクエリ変更を検知して自動的に再検索する。
+const SearchFilterChips = () => {
+  const router = useRouter();
+
+  const featuresParam = router.query.features;
+  const selected = new Set(
+    (Array.isArray(featuresParam) ? featuresParam.join(',') : featuresParam || '')
+      .split(',')
+      .filter(Boolean)
+  );
+
+  const toggleFeature = (key: string) => {
+    const next = new Set(selected);
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+
+    const query: Record<string, string | string[]> = { ...router.query } as Record<string, string | string[]>;
+    if (next.size > 0) {
+      query.features = Array.from(next).join(',');
+    } else {
+      delete query.features;
+    }
+
+    router.replace({ pathname: router.pathname, query }, undefined, { shallow: false });
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ px: { xs: 1.5, sm: 2 }, pt: 2 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 1,
+          overflowX: 'auto',
+          pb: 0.5,
+          // モバイルで横スクロールバーを目立たせない
+          scrollbarWidth: 'none',
+          '&::-webkit-scrollbar': { display: 'none' },
+        }}
+      >
+        {FEATURE_TAGS.map((tag) => {
+          const active = selected.has(tag.key);
+          return (
+            <Chip
+              key={tag.key}
+              label={tag.label}
+              size="small"
+              clickable
+              onClick={() => toggleFeature(tag.key)}
+              color={active ? 'primary' : 'default'}
+              variant={active ? 'filled' : 'outlined'}
+              sx={{ flexShrink: 0, fontWeight: 700 }}
+            />
+          );
+        })}
+      </Box>
+    </Container>
+  );
+};
+
+export default SearchFilterChips;

--- a/pages/api/restaurants/search.js
+++ b/pages/api/restaurants/search.js
@@ -56,6 +56,9 @@ export default async function handler(req, res) {
         whereClause.chuhai_price = { lte: parseInt(maxChuhaiPrice) };
       }
 
+      // ソフトデリート済み(=閉店扱い)の店舗は検索結果に出さない
+      whereClause.deleted_at = null;
+
       console.log('Final where clause:', JSON.stringify(whereClause, null, 2));
 
       console.log('Executing database query...');

--- a/pages/restaurants/search.tsx
+++ b/pages/restaurants/search.tsx
@@ -1,6 +1,7 @@
 import { LoadingState } from '@/components/common/LoadingState';
 import Navbar from '@/components/common/Navbar';
 import RestaurantList from '@/components/restaurant/RestaurantList';
+import SearchFilterChips from '@/components/restaurant/SearchFilterChips';
 import { useRestaurantSearch } from '@/hooks/restaurant/useRestaurantSearch';
 import styles from '@/styles/HomePage.module.css';
 import { Alert, Container } from '@mui/material';
@@ -35,6 +36,7 @@ const RestaurantListPage = () => {
         />
       </Head>
       <Navbar />
+      <SearchFilterChips />
       {error && (
         <Container maxWidth="sm" sx={{ pt: 2 }}>
           <Alert severity="warning">{error}</Alert>

--- a/utils/features.ts
+++ b/utils/features.ts
@@ -1,0 +1,17 @@
+// せんべろ属性のキーと表示ラベルの共通定義。
+// 検索結果カードのタグ表示と、検索結果画面の絞り込みチップで共用する。
+export const FEATURE_TAGS: { key: string; label: string }[] = [
+  { key: 'is_standing', label: '立ち飲み' },
+  { key: 'is_kakuuchi', label: '角打ち' },
+  { key: 'has_set', label: 'せんべろセット' },
+  { key: 'daytime_available', label: '昼飲み' },
+  { key: 'morning_available', label: '朝飲み' },
+  { key: 'has_happy_hour', label: 'ハッピーアワー' },
+  { key: 'has_chinchiro', label: 'チンチロ' },
+  { key: 'outside_available', label: '外飲み' },
+];
+
+// 距離(km)を徒歩分数に換算する（不動産表示で使われる80m/分基準）
+export const walkMinutes = (distanceKm: number): number => {
+  return Math.max(1, Math.ceil((distanceKm * 1000) / 80));
+};


### PR DESCRIPTION
## 概要

「実際にユーザーに使い続けてもらう」ための改善をissue化（#52〜#55）し、影響の大きいものから実装しました。はしご酒中の「見る→絞る→選ぶ」ループを検索結果画面内で完結させます。

### #52: カードにせんべろ属性タグと徒歩時間を表示

- 79店舗分入力したせんべろ属性（立ち飲み・角打ち・せんべろセット等）が詳細ページを開くまで見えなかった問題を解消。検索結果カードにタグとして表示
- 距離表示を「0.09km」から「徒歩2分（0.1km）」に変更（80m/分換算）

### #53: 検索結果画面での絞り込みチップ

- 結果一覧の上部に特徴をその場でトグルできる横スクロールチップ列を追加
- チップのON/OFFがURLクエリに反映され、イマココ検索（位置情報）を維持したまま絞り込める

### #55(一部): 閉店店舗の検索除外

- 検索APIに `deleted_at: null` フィルタを追加し、ソフトデリート済み店舗が検索結果に出ないようにした（管理画面からの閉店操作は別途）

## 動作確認

錦糸町駅の座標を模擬した実ブラウザで、タグ・徒歩時間の表示、チップによる絞り込み（立ち飲みのみに絞る→URLと結果が連動）、deleted_at付き店舗の除外をすべて確認済み。型チェック・lintもクリーン（既存警告のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDJtiGt9WuuispTsE2YHUt

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDJtiGt9WuuispTsE2YHUt)_