### PR TITLE
検索結果カードのレイアウト崩れを修正（画像の右側が空いていた）

### DIFF
--- a/components/restaurant/RestaurantCard.jsx
+++ b/components/restaurant/RestaurantCard.jsx
@@ -19,10 +19,13 @@ export const RestaurantCard = ({ restaurant, onClick }) => {
 
   return (
     <Card
-      className="flex flex-row overflow-hidden cursor-pointer"
       onClick={() => onClick(restaurant.restaurant_id)}
       sx={{
         position: 'relative',
+        display: 'flex',
+        flexDirection: 'row',
+        overflow: 'hidden',
+        cursor: 'pointer',
         transition: 'box-shadow 0.15s ease, transform 0.15s ease',
         '&:hover': {
           boxShadow: '0 6px 20px rgba(42, 32, 25, 0.14)',
@@ -42,7 +45,7 @@ export const RestaurantCard = ({ restaurant, onClick }) => {
       </Box>
 
       {/* Restaurant Details */}
-      <Box className="flex-1" sx={{ minWidth: 0 }}>
+      <Box sx={{ flexGrow: 1, minWidth: 0 }}>
         <CardContent sx={{ py: 1.5, pr: 8 }}>
           <Typography
             variant="subtitle1"


### PR DESCRIPTION
## 概要

検索結果一覧のカードで、画像が左上に小さく置かれて右側が空白になり、店名などの情報がその下に積まれてしまうレイアウト崩れを修正します。

## 原因

カードの横並びレイアウトがTailwindのクラス（`flex flex-row` / `flex-1`）に依存していましたが、Tailwindを読み込む`globals.css`がどこからもimportされておらず、これらのクラスが一切効いていませんでした。

## 修正

TailwindクラスをMUIの`sx`（`display: flex` / `flexGrow: 1`）に置き換え、コンポーネント単体で完結するレイアウトにしました。モバイル（420px）とPC（1280px）の両方で、画像左・情報右の意図したレイアウトになることをスクリーンショットで確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDJtiGt9WuuispTsE2YHUt

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDJtiGt9WuuispTsE2YHUt)_