### PR TITLE
イマココ検索の結果を徒歩15分圏内/圏外で区切って表示

### DIFF
--- a/components/restaurant/RestaurantCard.jsx
+++ b/components/restaurant/RestaurantCard.jsx
@@ -72,7 +72,9 @@ export const RestaurantCard = ({ restaurant, onClick }) => {
             <Box display="flex" alignItems="center" mt={0.5} sx={{ color: 'text.secondary' }}>
               <DirectionsRun sx={{ mr: 0.75, fontSize: 18 }} />
               <Typography variant="body2">
-                徒歩{walkMinutes(restaurant.distance)}分（{restaurant.distance.toFixed(1)}km）
+                {walkMinutes(restaurant.distance) <= 60
+                  ? `徒歩${walkMinutes(restaurant.distance)}分（${restaurant.distance.toFixed(1)}km）`
+                  : `${restaurant.distance.toFixed(1)}km`}
               </Typography>
             </Box>
           )}

--- a/components/restaurant/RestaurantList.tsx
+++ b/components/restaurant/RestaurantList.tsx
@@ -1,6 +1,8 @@
 import { useAppNavigation } from '@/hooks/useAppNavigation';
 import { Restaurant } from '@/types/restaurant';
-import { Box, Container, Stack, Typography } from '@mui/material';
+import { isWalkable, WALKABLE_LIMIT_MINUTES } from '@/utils/features';
+import { DirectionsWalk } from '@mui/icons-material';
+import { Box, Chip, Container, Divider, Stack, Typography } from '@mui/material';
 import { RestaurantCard } from './RestaurantCard';
 
 interface RestaurantListProps {
@@ -29,16 +31,47 @@ export const RestaurantList: React.FC<RestaurantListProps> = ({ restaurants }) =
     return <EmptyState />;
   }
 
+  const renderCard = (restaurant: Restaurant) => (
+    <RestaurantCard
+      key={restaurant.restaurant_id}
+      restaurant={restaurant}
+      onClick={() => restaurant.restaurant_id && navigationFunctions.toDetail(restaurant.restaurant_id)}
+    />
+  );
+
+  // イマココ検索(距離あり)の場合、徒歩圏内とそれ以遠の間に境界線を入れる。
+  // 結果は距離昇順で返ってくるため、前半=徒歩圏内・後半=圏外に二分できる
+  const hasDistance = restaurants.some((r) => r.distance != null);
+  const walkableList = hasDistance
+    ? restaurants.filter((r) => r.distance != null && isWalkable(r.distance))
+    : restaurants;
+  const farList = hasDistance
+    ? restaurants.filter((r) => r.distance == null || !isWalkable(r.distance))
+    : [];
+
   return (
     <Container maxWidth="sm" sx={{ px: { xs: 1.5, sm: 2 }, pt: 2 }}>
       <Stack spacing={1.5} sx={{ pb: 5 }}>
-        {restaurants.map((restaurant) => (
-          <RestaurantCard
-            key={restaurant.restaurant_id}
-            restaurant={restaurant}
-            onClick={() => restaurant.restaurant_id && navigationFunctions.toDetail(restaurant.restaurant_id)}
-          />
-        ))}
+        {walkableList.map(renderCard)}
+
+        {hasDistance && farList.length > 0 && (
+          <>
+            {walkableList.length === 0 && (
+              <Typography variant="body2" color="text.secondary" align="center" sx={{ py: 1 }}>
+                徒歩{WALKABLE_LIMIT_MINUTES}分圏内に条件に合うお店がありませんでした。
+              </Typography>
+            )}
+            <Divider sx={{ pt: 1 }}>
+              <Chip
+                icon={<DirectionsWalk />}
+                label={`ここから先は徒歩${WALKABLE_LIMIT_MINUTES}分以上`}
+                size="small"
+                sx={{ fontWeight: 700, color: 'text.secondary' }}
+              />
+            </Divider>
+            {farList.map(renderCard)}
+          </>
+        )}
       </Stack>
     </Container>
   );

--- a/types/restaurant.ts
+++ b/types/restaurant.ts
@@ -64,6 +64,9 @@ export interface Restaurant {
   qr_payment?: boolean;
   deleted_at?: Date;
 
+  // イマココ検索時に検索APIが付与する現在地からの距離(km)
+  distance?: number;
+
   operating_hours?: OperatingHour[];
 }
 

--- a/utils/features.ts
+++ b/utils/features.ts
@@ -17,3 +17,11 @@ export const FEATURE_TAGS: { key: string; label: string }[] = [
 export const walkMinutes = (distanceKm: number): number => {
   return Math.max(1, Math.ceil((distanceKm * 1000) / 80));
 };
+
+// はしご酒で「歩いて行ける」と見なす上限(分)。
+// イマココ検索の結果リストはこの境界で区切って表示する。
+export const WALKABLE_LIMIT_MINUTES = 15;
+
+export const isWalkable = (distanceKm: number): boolean => {
+  return walkMinutes(distanceKm) <= WALKABLE_LIMIT_MINUTES;
+};


### PR DESCRIPTION
## 概要

はしご酒で「歩いて行ける店」と「現実的に歩けない店」の境界を検索結果リスト上で明示します。

- 徒歩15分（80m/分換算で1.2km）を境界とし、イマココ検索の結果リストの15分圏内と圏外の間に「ここから先は徒歩15分以上」の区切り線（チップ付きDivider）を挿入
- 圏内に該当店舗が0件の場合は「徒歩15分圏内に条件に合うお店がありませんでした。」のメッセージを表示
- 遠方の店舗（徒歩60分超）は「徒歩19531分」のような非現実的な表示をやめ、距離(km)のみの表示に変更
- 検索APIが付与する`distance`をRestaurant型に追加（型エラーの解消）

## 動作確認

錦糸町駅の座標を模擬した実ブラウザで、区切り線の表示・圏内0件時のメッセージ・遠方店の距離表示をスクリーンショットで確認済み。型チェック・lintもクリーン（既存警告のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDJtiGt9WuuispTsE2YHUt

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDJtiGt9WuuispTsE2YHUt)_