### PR TITLE
SEO対策: 店舗詳細のSSR化・構造化データ・エリア別ランディングページ

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,15 @@
+import { getSiteUrl } from '@/lib/siteUrl';
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = getSiteUrl();
+
+  return {
+    rules: {
+      userAgent: '*',
+      disallow: ['/admin', '/api'],
+    },
+    // robots.txtのSitemap行は仕様上絶対URLである必要がある
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,18 +1,23 @@
-import { PrismaClient } from '@prisma/client';
+import { AREAS } from '@/lib/areas';
+import prisma from '@/lib/prisma';
+import { getSiteUrl } from '@/lib/siteUrl';
 import type { MetadataRoute } from 'next';
 
-const prisma = new PrismaClient();
-
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+  const baseUrl = getSiteUrl();
 
   const restaurants = await prisma.restaurant.findMany({
+    where: { deleted_at: null },
     select: { restaurant_id: true, updated_at: true },
   });
 
   const staticRoutes: MetadataRoute.Sitemap = [
     { url: baseUrl, lastModified: new Date() },
     { url: `${baseUrl}/restaurants/search`, lastModified: new Date() },
+    ...AREAS.map((area) => ({
+      url: `${baseUrl}/areas/${area.slug}`,
+      lastModified: new Date(),
+    })),
   ];
 
   const restaurantRoutes: MetadataRoute.Sitemap = restaurants.map((restaurant) => ({

--- a/components/restaurant/RestaurantCard.jsx
+++ b/components/restaurant/RestaurantCard.jsx
@@ -6,7 +6,8 @@ import { getTodayOperatingHours } from '../../utils/dateUtils';
 import { FEATURE_TAGS, walkMinutes } from '../../utils/features';
 
 
-export const RestaurantCard = ({ restaurant, onClick }) => {
+// href を渡すと店名が実リンク(<a>)になり、クローラーが詳細ページを辿れる
+export const RestaurantCard = ({ restaurant, onClick, href = '' }) => {
   const activeTags = FEATURE_TAGS.filter((tag) => restaurant[tag.key]);
 
   const handleMapClick = (e) => {
@@ -49,8 +50,16 @@ export const RestaurantCard = ({ restaurant, onClick }) => {
         <CardContent sx={{ py: 1.5, pr: 8 }}>
           <Typography
             variant="subtitle1"
-            component="div"
-            sx={{ fontWeight: 700, lineHeight: 1.3, mb: 1 }}
+            component={href ? 'a' : 'div'}
+            href={href || undefined}
+            sx={{
+              display: 'block',
+              fontWeight: 700,
+              lineHeight: 1.3,
+              mb: 1,
+              color: 'inherit',
+              textDecoration: 'none',
+            }}
           >
             {restaurant.name}
           </Typography>

--- a/components/restaurant/SearchForm.js
+++ b/components/restaurant/SearchForm.js
@@ -17,8 +17,10 @@ import {
   Typography, useMediaQuery
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
+import { AREAS } from '@/lib/areas';
 
 const SearchForm = () => {
   const router = useRouter();
@@ -271,6 +273,21 @@ const SearchForm = () => {
         >
           特徴から検索
         </Button>
+      </Box>
+
+      <Box sx={{ mt: 6, textAlign: 'center' }}>
+        <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1.5, color: 'text.secondary' }}>
+          エリアから探す
+        </Typography>
+        <Box sx={{ display: 'flex', justifyContent: 'center', gap: 3, flexWrap: 'wrap' }}>
+          {AREAS.map((area) => (
+            <Link key={area.slug} href={`/areas/${area.slug}`} style={{ textDecoration: 'none' }}>
+              <Typography variant="body1" sx={{ fontWeight: 700, color: 'primary.dark' }}>
+                {area.label}
+              </Typography>
+            </Link>
+          ))}
+        </Box>
       </Box>
 
       <Dialog open={openFeatureDialog} onClose={handleFeatureDialogClose} maxWidth="md" fullWidth>

--- a/lib/areas.ts
+++ b/lib/areas.ts
@@ -1,0 +1,42 @@
+// エリア別ランディングページの定義。
+// slugがURL(/areas/[slug])、citiesはRestaurant.cityとの対応
+export interface AreaDef {
+  slug: string;
+  label: string;
+  cities: string[];
+  description: string;
+}
+
+export const AREAS: AreaDef[] = [
+  {
+    slug: 'ueno',
+    label: '上野',
+    cities: ['台東区'],
+    description:
+      '上野・御徒町・アメ横エリアは、朝飲みできる老舗立ち飲みから角打ち、せんべろセットの名店までが高架下にひしめく、都内屈指のせんべろ激戦区です。',
+  },
+  {
+    slug: 'kinshicho',
+    label: '錦糸町',
+    cities: ['墨田区', '江東区'],
+    description:
+      '錦糸町・住吉エリアは、駅前の大衆酒場から下町の角打ち・ホッピー専門店まで、はしご酒にちょうどいい距離感で名店が点在しています。',
+  },
+  {
+    slug: 'akabane',
+    label: '赤羽',
+    cities: ['北区'],
+    description:
+      '「せんべろの聖地」とも呼ばれる赤羽。朝7時から開く伝説の立ち飲みや24時間営業のキャッシュオン酒場など、昼夜を問わず飲める街です。',
+  },
+  {
+    slug: 'naha',
+    label: '那覇',
+    cities: ['那覇市'],
+    description:
+      '那覇・牧志公設市場周辺は、1,000円で3杯+おつまみが定番の「せんべろ文化」が根付く沖縄随一の飲み屋街。昼から立ち飲みでオリオンビールが楽しめます。',
+  },
+];
+
+export const findArea = (slug: string): AreaDef | undefined =>
+  AREAS.find((area) => area.slug === slug);

--- a/lib/siteUrl.ts
+++ b/lib/siteUrl.ts
@@ -1,0 +1,10 @@
+// 本番ドメインの解決。NEXT_PUBLIC_SITE_URL(明示設定) > VERCEL_URL > localhost
+export const getSiteUrl = (): string => {
+  if (process.env.NEXT_PUBLIC_SITE_URL) {
+    return process.env.NEXT_PUBLIC_SITE_URL.replace(/\/$/, '');
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  return 'http://localhost:3000';
+};

--- a/pages/areas/[slug].tsx
+++ b/pages/areas/[slug].tsx
@@ -1,0 +1,106 @@
+// pages/areas/[slug].tsx エリア別ランディングページ(SSR)
+import Navbar from '@/components/common/Navbar';
+import { RestaurantCard } from '@/components/restaurant/RestaurantCard';
+import { AREAS, findArea } from '@/lib/areas';
+import prisma from '@/lib/prisma';
+import { getSiteUrl } from '@/lib/siteUrl';
+import styles from '@/styles/HomePage.module.css';
+import { Restaurant } from '@/types/restaurant';
+import { Box, Container, Stack, Typography } from '@mui/material';
+import type { GetServerSideProps } from 'next';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+interface AreaPageProps {
+  slug: string;
+  label: string;
+  areaDescription: string;
+  restaurants: Restaurant[];
+  siteUrl: string;
+}
+
+const AreaPage: React.FC<AreaPageProps> = ({ slug, label, areaDescription, restaurants, siteUrl }) => {
+  const router = useRouter();
+  const title = `${label}のせんべろ・立ち飲み・大衆酒場一覧(${restaurants.length}件) | せんべろCheers`;
+  const description = `${areaDescription} ${label}エリアの登録店舗${restaurants.length}件を掲載中。`;
+  const canonicalUrl = `${siteUrl}/areas/${slug}`;
+
+  return (
+    <div className={styles.container}>
+      <Head>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:site_name" content="せんべろCheers" />
+      </Head>
+      <Navbar />
+      <Container maxWidth="sm" sx={{ px: { xs: 1.5, sm: 2 }, pt: 3 }}>
+        <Typography variant="h5" component="h1" sx={{ fontWeight: 800, mb: 1 }}>
+          {label}のせんべろ・立ち飲み・大衆酒場
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+          {areaDescription}
+        </Typography>
+
+        <Stack spacing={1.5} sx={{ pb: 3 }}>
+          {restaurants.map((restaurant) => (
+            <RestaurantCard
+              key={restaurant.restaurant_id}
+              restaurant={restaurant}
+              href={`/restaurants/${restaurant.restaurant_id}`}
+              onClick={() => router.push(`/restaurants/${restaurant.restaurant_id}`)}
+            />
+          ))}
+        </Stack>
+
+        <Box sx={{ pb: 5 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1 }}>
+            他のエリアから探す
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+            {AREAS.filter((area) => area.slug !== slug).map((area) => (
+              <Link key={area.slug} href={`/areas/${area.slug}`}>
+                <Typography variant="body2" color="primary.dark" sx={{ fontWeight: 700 }}>
+                  {area.label}
+                </Typography>
+              </Link>
+            ))}
+          </Box>
+        </Box>
+      </Container>
+    </div>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+  const slug = params?.slug as string;
+  const area = findArea(slug);
+  if (!area) {
+    return { notFound: true };
+  }
+
+  const restaurants = await prisma.restaurant.findMany({
+    where: {
+      city: { in: area.cities },
+      deleted_at: null,
+    },
+    include: { operating_hours: true },
+    orderBy: { restaurant_id: 'asc' },
+  });
+
+  return {
+    props: {
+      slug,
+      label: area.label,
+      areaDescription: area.description,
+      restaurants: JSON.parse(JSON.stringify(restaurants)),
+      siteUrl: getSiteUrl(),
+    },
+  };
+};
+
+export default AreaPage;

--- a/pages/restaurants/[id]/index.tsx
+++ b/pages/restaurants/[id]/index.tsx
@@ -1,56 +1,134 @@
 // pages/restaurants/[id]/index.tsx
-import { ErrorState } from '@/components/common/ErrorState';
-import { LoadingState } from '@/components/common/LoadingState';
 import Navbar from '@/components/common/Navbar';
 import RestaurantDetail from '@/components/restaurant/RestaurantDetail';
-import { useRestaurantDetail } from '@/hooks/restaurant/useRestaurantDetail';
+import prisma from '@/lib/prisma';
+import { getSiteUrl } from '@/lib/siteUrl';
 import styles from '@/styles/HomePage.module.css';
+import { Restaurant } from '@/types/restaurant';
+import type { GetServerSideProps } from 'next';
 import Head from 'next/head';
-import { useRouter } from 'next/router';
-import { useMemo } from 'react';
 
-const RestaurantDetailPage: React.FC = () => {
-  const router = useRouter();
-  const { id } = router.query;
-  const { restaurant, loading, error } = useRestaurantDetail(id as string);
+interface RestaurantDetailPageProps {
+  restaurant: Restaurant;
+  siteUrl: string;
+}
 
-  const restaurantDetailComponent = useMemo(() => {
-    if (loading) {
-      return <LoadingState />;
-    }
+// 曜日番号をschema.orgのdayOfWeek表記へ
+const SCHEMA_DAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
-    if (error) {
-      return <ErrorState error={error} />;
-    }
+const toTimeString = (value?: Date | string) => {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (isNaN(date.getTime())) return undefined;
+  // 営業時間はJSTの時刻が1970-01-01のUTC時刻として保存されている
+  const jst = new Date(date.getTime() - 9 * 60 * 60 * 1000);
+  return jst.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: 'Asia/Tokyo' });
+};
 
-    if (!restaurant) {
-      return (
-        <div className={styles.notFoundContainer}>
-          <p>Restaurant not found</p>
-        </div>
-      );
-    }
+const RestaurantDetailPage: React.FC<RestaurantDetailPageProps> = ({ restaurant, siteUrl }) => {
+  const areaLabel = `${restaurant.state ?? ''}${restaurant.city ?? ''}`;
+  const title = `${restaurant.name} | ${areaLabel}のせんべろ・大衆酒場 | せんべろCheers`;
+  const features = [
+    restaurant.is_standing && '立ち飲み',
+    restaurant.is_kakuuchi && '角打ち',
+    restaurant.has_set && 'せんべろセット',
+    restaurant.daytime_available && '昼飲み',
+    restaurant.morning_available && '朝飲み',
+  ].filter(Boolean).join('・');
+  const description = restaurant.description
+    ? `${restaurant.name}(${areaLabel})。${restaurant.description}`
+    : `${restaurant.name}(${areaLabel})の営業時間・${features || 'せんべろ情報'}。`;
+  const canonicalUrl = `${siteUrl}/restaurants/${restaurant.restaurant_id}`;
+  const imageUrl = restaurant.restaurant_image || `${siteUrl}/default-restaurant-image.jpg`;
 
-    return <RestaurantDetail restaurant={restaurant} />;
-  }, [restaurant, loading, error]);
-
-  const title = restaurant?.name ? `${restaurant.name} | せんべろCheers` : 'せんべろCheers';
-  const description = restaurant
-    ? `${restaurant.name}(${restaurant.city ?? ''}${restaurant.address_line1 ?? ''})の営業時間・立ち飲み/角打ち/せんべろセットの有無などの情報。`
-    : '大衆酒場・立ち飲み・せんべろの検索アプリ「せんべろCheers」。';
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BarOrPub',
+    name: restaurant.name,
+    url: canonicalUrl,
+    image: imageUrl,
+    servesCuisine: '居酒屋',
+    address: {
+      '@type': 'PostalAddress',
+      addressRegion: restaurant.state,
+      addressLocality: restaurant.city,
+      streetAddress: `${restaurant.address_line1 ?? ''}${restaurant.address_line2 ?? ''}`,
+      addressCountry: 'JP',
+    },
+    geo: {
+      '@type': 'GeoCoordinates',
+      latitude: restaurant.latitude,
+      longitude: restaurant.longitude,
+    },
+    ...(restaurant.phone_number ? { telephone: restaurant.phone_number } : {}),
+    ...(restaurant.set_price || restaurant.beer_price
+      ? { priceRange: `¥${restaurant.set_price || restaurant.beer_price}~` }
+      : {}),
+    ...(restaurant.operating_hours && restaurant.operating_hours.length > 0
+      ? {
+          openingHoursSpecification: restaurant.operating_hours
+            .map((hour) => {
+              const opens = toTimeString(hour.open_time);
+              const closes = toTimeString(hour.close_time);
+              if (!opens || !closes) return null;
+              return {
+                '@type': 'OpeningHoursSpecification',
+                dayOfWeek: SCHEMA_DAYS[hour.day_of_week],
+                opens,
+                closes,
+              };
+            })
+            .filter(Boolean),
+        }
+      : {}),
+  };
 
   return (
     <div className={styles.container}>
       <Head>
         <title>{title}</title>
         <meta name="description" content={description} />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:type" content="article" />
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:image" content={imageUrl} />
+        <meta property="og:site_name" content="せんべろCheers" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
       </Head>
       <Navbar />
-      {restaurantDetailComponent}
+      <RestaurantDetail restaurant={restaurant} />
     </div>
   );
+};
+
+export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+  const id = parseInt(params?.id as string, 10);
+  if (isNaN(id)) {
+    return { notFound: true };
+  }
+
+  const restaurant = await prisma.restaurant.findUnique({
+    where: { restaurant_id: id },
+    include: { operating_hours: true },
+  });
+
+  if (!restaurant || restaurant.deleted_at) {
+    return { notFound: true };
+  }
+
+  return {
+    props: {
+      // Date型はそのままpropsに渡せないためJSONシリアライズする
+      restaurant: JSON.parse(JSON.stringify(restaurant)),
+      siteUrl: getSiteUrl(),
+    },
+  };
 };
 
 export default RestaurantDetailPage;

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,0 @@
-User-agent: *
-Disallow: /admin
-Disallow: /api
-
-Sitemap: /sitemap.xml


### PR DESCRIPTION
## 概要

これまで店舗詳細ページはクライアントサイドレンダリングで、**クローラーには店名を1文字も含まない空のHTML**（タイトルも汎用の「せんべろCheers」のまま）しか見えていませんでした。検索流入の受け皿として機能させるための対応です。

### 店舗詳細ページのSSR化 + 構造化データ

- `getServerSideProps`でサーバーレンダリングし、店名・エリア入りのtitle/description・canonical・OGP・schema.orgの`BarOrPub`構造化データ（住所・緯度経度・営業時間・価格帯）を初期HTMLに含める
- 存在しない/削除済み店舗は404

### エリア別ランディングページ（/areas/ueno 等）

- 「上野 せんべろ」「錦糸町 立ち飲み」等の検索クエリの受け皿となるSSRページを4エリア分新設（上野・錦糸町・赤羽・那覇）
- 店名が実リンク（`<a href>`）のため、クローラーが全店舗の詳細ページへ到達できる内部リンク網としても機能
- トップページに「エリアから探す」リンクを追加

### sitemap / robots の修正

- sitemapから削除済み店舗を除外（従来は含まれていた）、エリアページを追加
- robots.txtを動的生成に変更し、仕様上絶対URLが必要なSitemap行を`NEXT_PUBLIC_SITE_URL`/`VERCEL_URL`から生成

## 検証

- JSなしのcurlで、詳細ページのHTMLにtitle（店名入り）・JSON-LD・店名本文が含まれることを確認
- エリアページに32件（上野）の実リンクが含まれ、実ブラウザでhydrationエラーなし・リンク遷移も正常
- 削除済み店舗が詳細404かつsitemapから除外されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDJtiGt9WuuispTsE2YHUt

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDJtiGt9WuuispTsE2YHUt)_