### PR TITLE
Google Search Console所有権確認用のメタタグを追加

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -43,6 +43,10 @@ export default function App({ Component, pageProps: { session, ...pageProps } }:
           content="大衆酒場・立ち飲み・せんべろ・角打ち・昼飲みが好きな人のための飲食店検索アプリ。せんべろセットや昼飲み・朝飲みの可否など、こだわり条件からお店を探せます。"
         />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+          name="google-site-verification"
+          content="bjXi7Bv1l1GI-xO_rDClhhwBZ_sAPPQIeaqEiUzzbO8"
+        />
       </Head>
       <Script
         strategy="afterInteractive"


### PR DESCRIPTION
## 概要

Google Search Consoleの所有権確認のため、全ページ共通の`<Head>`に`google-site-verification`メタタグを追加します。

`senbero-next.vercel.app`はVercel管理の`vercel.app`ドメイン配下のためDNSにTXTレコードを追加できず、ドメインプロパティ方式は使えません。URLプレフィックス型プロパティのHTMLタグ方式で確認します（確認トークンはHTMLに公開される情報のためハードコードで問題ありません）。

ローカルでトップページのHTMLにメタタグが出力されることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDJtiGt9WuuispTsE2YHUt

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDJtiGt9WuuispTsE2YHUt)_