### PR TITLE
Search Console所有権確認トークンをHTMLタグ方式の値に差し替え

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -45,7 +45,7 @@ export default function App({ Component, pageProps: { session, ...pageProps } }:
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta
           name="google-site-verification"
-          content="bjXi7Bv1l1GI-xO_rDClhhwBZ_sAPPQIeaqEiUzzbO8"
+          content="Qxffro3ZPpbQwduDpTvQ1NbU1kSEOZoes-CM3B2Mnc8"
         />
       </Head>
       <Script


### PR DESCRIPTION
## 概要

Google Search ConsoleのHTMLタグ方式で実際に発行されたトークン（`Qxffro3Z...`）に、`google-site-verification`メタタグの値を差し替えます。前回埋め込んだのはDNS TXTレコード方式用のトークンで、HTMLタグ方式とは値が異なっていました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDJtiGt9WuuispTsE2YHUt

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDJtiGt9WuuispTsE2YHUt)_