### PR TITLE
管理用seed実行API（/api/admin/seed）を追加

### DIFF
--- a/app/api/admin/seed/route.js
+++ b/app/api/admin/seed/route.js
@@ -1,0 +1,39 @@
+import { seedRestaurantsFromCsv } from '@/lib/seedRestaurants';
+import { PrismaClient } from '@prisma/client';
+import { NextResponse } from 'next/server';
+import path from 'path';
+
+const prisma = new PrismaClient();
+
+// 本番DBへ直接接続せずにdata/restaurants.csvを反映するための管理用エンドポイント。
+// middlewareにより/api/admin配下は常にBasic認証で保護される。
+// Vercelのサーバーレス関数のデフォルトタイムアウトでは足りない可能性があるため延長
+export const maxDuration = 60;
+export const dynamic = 'force-dynamic';
+
+async function runSeed() {
+  const filePath = path.join(process.cwd(), 'data', 'restaurants.csv');
+  const logs = [];
+  const result = await seedRestaurantsFromCsv(prisma, filePath, (msg) => logs.push(msg));
+
+  return NextResponse.json({
+    ok: result.errors.length === 0,
+    ...result,
+    // ログは長いので末尾だけ返す
+    recentLogs: logs.slice(-10),
+  }, { status: result.errors.length === 0 ? 200 : 500 });
+}
+
+export async function POST() {
+  try {
+    return await runSeed();
+  } catch (error) {
+    console.error('Seed API error:', error);
+    return NextResponse.json({ ok: false, error: String(error.message || error) }, { status: 500 });
+  }
+}
+
+// ブラウザのアドレスバーから直接叩けるようGETも許可(管理者専用・Basic認証必須)
+export async function GET() {
+  return POST();
+}

--- a/lib/seedRestaurants.js
+++ b/lib/seedRestaurants.js
@@ -1,0 +1,179 @@
+// data/restaurants.csv をDBへ反映する共通ロジック。
+// CLI(prisma/seed.js)と管理用APIルート(/api/admin/seed)の両方から使う。
+import csv from 'csv-parser'
+import fs from 'fs'
+
+function isValidDate(dateString) {
+  return !isNaN(Date.parse(dateString))
+}
+
+function formatDateTime(timeString) {
+  const defaultDate = '1970-01-01'
+  const dateTimeString = `${defaultDate}T${timeString}.000Z`
+
+  const date = new Date(dateTimeString)
+  if (isNaN(date.getTime())) {
+    return null
+  }
+
+  return date
+}
+
+function parseBoolean(value) {
+  if (value === null || value === undefined) return false
+  return value.toLowerCase() === 'true' || value === '1'
+}
+
+function parseDayOfWeek(day) {
+  const days = ['日', '月', '火', '水', '木', '金', '土']
+  const index = days.indexOf(day)
+  return index !== -1 ? index : parseInt(day, 10)
+}
+
+function parseIntOrNull(value) {
+  if (!value) return null
+  const num = parseInt(value, 10)
+  return isNaN(num) ? null : num
+}
+
+function buildRestaurantData(row, now) {
+  return {
+    name: row.name || undefined,
+    phone_number: row.phone_number || null,
+    country: row.country || '日本',
+    state: row.state || '',
+    city: row.city || '',
+    address_line1: row.address_line1 || '',
+    address_line2: row.address_line2 || '',
+    latitude: row.latitude ? parseFloat(row.latitude) : 0,
+    longitude: row.longitude ? parseFloat(row.longitude) : 0,
+    capacity: parseIntOrNull(row.capacity),
+    home_page: row.home_page || null,
+    description: row.description || null,
+    special_rule: row.special_rule || null,
+    morning_available: parseBoolean(row.morning_available),
+    daytime_available: parseBoolean(row.daytime_available),
+    has_set: parseBoolean(row.has_set),
+    senbero_description: row.senbero_description || null,
+    has_chinchiro: parseBoolean(row.has_chinchiro),
+    chinchiro_description: row.chinchiro_description || null,
+    outside_available: parseBoolean(row.outside_available),
+    outside_description: row.outside_description || null,
+    is_standing: parseBoolean(row.is_standing),
+    standing_description: row.standing_description || null,
+    is_kakuuchi: parseBoolean(row.is_kakuuchi),
+    is_cash_on: parseBoolean(row.is_cash_on),
+    has_charge: parseBoolean(row.has_charge),
+    charge_description: row.charge_description || null,
+    has_tv: parseBoolean(row.has_tv),
+    smoking_allowed: parseBoolean(row.smoking_allowed),
+    has_happy_hour: parseBoolean(row.has_happy_hour),
+    restaurant_image: row.restaurant_image || null,
+    credit_card: parseBoolean(row.credit_card),
+    credit_card_description: row.credit_card_description || null,
+    beer_price: parseIntOrNull(row.beer_price),
+    beer_types: row.beer_types || null,
+    chuhai_price: parseIntOrNull(row.chuhai_price),
+    set_price: parseIntOrNull(row.set_price),
+    signature_menu: row.signature_menu || null,
+    has_hoppy: parseBoolean(row.has_hoppy),
+    solo_friendly: parseBoolean(row.solo_friendly),
+    nearest_station: row.nearest_station || null,
+    happy_hour_description: row.happy_hour_description || null,
+    qr_payment: parseBoolean(row.qr_payment),
+    created_at: isValidDate(row.created_at) ? new Date(row.created_at) : now,
+    updated_at: now,
+  }
+}
+
+export async function seedRestaurantsFromCsv(prisma, filePath, log = console.log) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`CSV file not found: ${filePath}`)
+  }
+
+  const results = []
+  await new Promise((resolve, reject) => {
+    fs.createReadStream(filePath)
+      .pipe(csv())
+      .on('data', (data) => results.push(data))
+      .on('end', () => resolve())
+      .on('error', (error) => reject(error))
+  })
+
+  log(`CSV parsing completed. ${results.length} rows found.`)
+
+  // CSVは「1店舗 x 営業曜日」で複数行になっているため、店舗ごとにまとめる
+  const restaurantRows = new Map()
+  for (const row of results) {
+    const id = parseInt(row.restaurant_id, 10)
+    if (isNaN(id)) continue
+    if (!restaurantRows.has(id)) {
+      restaurantRows.set(id, [])
+    }
+    restaurantRows.get(id).push(row)
+  }
+
+  log(`${restaurantRows.size} unique restaurants found.`)
+
+  const now = new Date()
+  const errors = []
+  let upserted = 0
+
+  for (const [restaurantId, rows] of restaurantRows) {
+    const data = buildRestaurantData(rows[0], now)
+
+    try {
+      // 冪等にするため upsert: 既存店舗は属性を更新、新規は作成
+      await prisma.restaurant.upsert({
+        where: { restaurant_id: restaurantId },
+        update: data,
+        create: { restaurant_id: restaurantId, ...data },
+      })
+
+      // 営業時間は洗い替え(全削除→再作成)。重複登録を防ぐ
+      await prisma.operatingHour.deleteMany({
+        where: { restaurant_id: restaurantId },
+      })
+
+      const hoursData = rows
+        .filter((row) => row.day_of_week !== undefined && row.day_of_week !== '')
+        .map((row) => ({
+          restaurant_id: restaurantId,
+          day_of_week: parseDayOfWeek(row.day_of_week),
+          open_time: row.open_time ? formatDateTime(row.open_time) : null,
+          close_time: row.close_time ? formatDateTime(row.close_time) : null,
+          drink_last_order_time: row.drink_last_order_time ? formatDateTime(row.drink_last_order_time) : null,
+          food_last_order_time: row.food_last_order_time ? formatDateTime(row.food_last_order_time) : null,
+          happy_hour_start: row.happy_hour_start ? formatDateTime(row.happy_hour_start) : null,
+          happy_hour_end: row.happy_hour_end ? formatDateTime(row.happy_hour_end) : null,
+          created_at: now,
+          updated_at: now,
+        }))
+        .filter((h) => h.open_time && h.close_time)
+
+      if (hoursData.length > 0) {
+        await prisma.operatingHour.createMany({ data: hoursData })
+      }
+
+      upserted += 1
+      log(`Upserted restaurant ${restaurantId} (${data.name}) with ${hoursData.length} operating hours`)
+    } catch (dbError) {
+      errors.push({ restaurantId, message: String(dbError.message || dbError) })
+      log(`Database error for restaurant ${restaurantId}: ${dbError}`)
+    }
+  }
+
+  // CSVはrestaurant_idを明示して投入するため、autoincrementのシーケンスが
+  // 進まない。このままだと新規店舗の作成が既存IDと衝突して失敗するので、
+  // シーケンスを現在の最大IDに合わせる
+  await prisma.$executeRawUnsafe(
+    `SELECT setval(pg_get_serial_sequence('"Restaurant"', 'restaurant_id'), (SELECT COALESCE(MAX(restaurant_id), 1) FROM "Restaurant"))`
+  )
+  log('Restaurant id sequence synced')
+
+  return {
+    totalRestaurants: restaurantRows.size,
+    upserted,
+    errors,
+  }
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,12 @@ const nextConfig = {
   reactStrictMode: true,
   experimental: {
     esmExternals: 'loose',
+    // /api/admin/seed が実行時にCSVを読むため、サーバーレス関数の
+    // バンドルに data/ を含める(これがないとVercel上でファイルが見つからない)
+    outputFileTracingIncludes: {
+      '/api/admin/seed': ['./data/restaurants.csv'],
+      '/api/admin/seed/route': ['./data/restaurants.csv'],
+    },
   },
   images: {
     remotePatterns: [

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,183 +1,18 @@
 import { PrismaClient } from '@prisma/client'
-import csv from 'csv-parser'
-import fs from 'fs'
 import path from 'path'
+import { seedRestaurantsFromCsv } from '../lib/seedRestaurants.js'
 
 const prisma = new PrismaClient()
 
-function isValidDate(dateString) {
-  return !isNaN(Date.parse(dateString))
-}
-
-function formatDateTime(timeString) {
-  const defaultDate = '1970-01-01'
-  const dateTimeString = `${defaultDate}T${timeString}.000Z`
-
-  const date = new Date(dateTimeString)
-  if (isNaN(date.getTime())) {
-    return null
-  }
-
-  return date
-}
-
-function parseBoolean(value) {
-  if (value === null || value === undefined) return false
-  return value.toLowerCase() === 'true' || value === '1'
-}
-
-function parseDayOfWeek(day) {
-  const days = ['日', '月', '火', '水', '木', '金', '土']
-  const index = days.indexOf(day)
-  return index !== -1 ? index : parseInt(day, 10)
-}
-
-function parseIntOrNull(value) {
-  if (!value) return null
-  const num = parseInt(value, 10)
-  return isNaN(num) ? null : num
-}
-
-function buildRestaurantData(row, now) {
-  return {
-    name: row.name || undefined,
-    phone_number: row.phone_number || null,
-    country: row.country || '日本',
-    state: row.state || '',
-    city: row.city || '',
-    address_line1: row.address_line1 || '',
-    address_line2: row.address_line2 || '',
-    latitude: row.latitude ? parseFloat(row.latitude) : 0,
-    longitude: row.longitude ? parseFloat(row.longitude) : 0,
-    capacity: parseIntOrNull(row.capacity),
-    home_page: row.home_page || null,
-    description: row.description || null,
-    special_rule: row.special_rule || null,
-    morning_available: parseBoolean(row.morning_available),
-    daytime_available: parseBoolean(row.daytime_available),
-    has_set: parseBoolean(row.has_set),
-    senbero_description: row.senbero_description || null,
-    has_chinchiro: parseBoolean(row.has_chinchiro),
-    chinchiro_description: row.chinchiro_description || null,
-    outside_available: parseBoolean(row.outside_available),
-    outside_description: row.outside_description || null,
-    is_standing: parseBoolean(row.is_standing),
-    standing_description: row.standing_description || null,
-    is_kakuuchi: parseBoolean(row.is_kakuuchi),
-    is_cash_on: parseBoolean(row.is_cash_on),
-    has_charge: parseBoolean(row.has_charge),
-    charge_description: row.charge_description || null,
-    has_tv: parseBoolean(row.has_tv),
-    smoking_allowed: parseBoolean(row.smoking_allowed),
-    has_happy_hour: parseBoolean(row.has_happy_hour),
-    restaurant_image: row.restaurant_image || null,
-    credit_card: parseBoolean(row.credit_card),
-    credit_card_description: row.credit_card_description || null,
-    beer_price: parseIntOrNull(row.beer_price),
-    beer_types: row.beer_types || null,
-    chuhai_price: parseIntOrNull(row.chuhai_price),
-    set_price: parseIntOrNull(row.set_price),
-    signature_menu: row.signature_menu || null,
-    has_hoppy: parseBoolean(row.has_hoppy),
-    solo_friendly: parseBoolean(row.solo_friendly),
-    nearest_station: row.nearest_station || null,
-    happy_hour_description: row.happy_hour_description || null,
-    qr_payment: parseBoolean(row.qr_payment),
-    created_at: isValidDate(row.created_at) ? new Date(row.created_at) : now,
-    updated_at: now,
-  }
-}
-
 async function main() {
   console.log('Seeding process started')
-
   const filePath = path.join(process.cwd(), 'data', 'restaurants.csv')
-
-  if (!fs.existsSync(filePath)) {
-    console.error(`File not found: ${filePath}`)
+  const result = await seedRestaurantsFromCsv(prisma, filePath)
+  console.log(`Seeding completed: ${result.upserted}/${result.totalRestaurants} restaurants upserted, ${result.errors.length} errors`)
+  if (result.errors.length > 0) {
+    console.error(result.errors)
     process.exit(1)
   }
-
-  const results = []
-  await new Promise((resolve, reject) => {
-    fs.createReadStream(filePath)
-      .pipe(csv())
-      .on('data', (data) => results.push(data))
-      .on('end', () => resolve())
-      .on('error', (error) => {
-        console.error('Error reading CSV:', error)
-        reject(error)
-      })
-  })
-
-  console.log(`CSV parsing completed. ${results.length} rows found.`)
-
-  // CSVは「1店舗 x 営業曜日」で複数行になっているため、店舗ごとにまとめる
-  const restaurantRows = new Map()
-  for (const row of results) {
-    const id = parseInt(row.restaurant_id, 10)
-    if (isNaN(id)) continue
-    if (!restaurantRows.has(id)) {
-      restaurantRows.set(id, [])
-    }
-    restaurantRows.get(id).push(row)
-  }
-
-  console.log(`${restaurantRows.size} unique restaurants found.`)
-
-  const now = new Date()
-
-  for (const [restaurantId, rows] of restaurantRows) {
-    const data = buildRestaurantData(rows[0], now)
-
-    try {
-      // 冪等にするため upsert: 既存店舗は属性を更新、新規は作成
-      await prisma.restaurant.upsert({
-        where: { restaurant_id: restaurantId },
-        update: data,
-        create: { restaurant_id: restaurantId, ...data },
-      })
-
-      // 営業時間は洗い替え(全削除→再作成)。重複登録を防ぐ
-      await prisma.operatingHour.deleteMany({
-        where: { restaurant_id: restaurantId },
-      })
-
-      const hoursData = rows
-        .filter((row) => row.day_of_week !== undefined && row.day_of_week !== '')
-        .map((row) => ({
-          restaurant_id: restaurantId,
-          day_of_week: parseDayOfWeek(row.day_of_week),
-          open_time: row.open_time ? formatDateTime(row.open_time) : null,
-          close_time: row.close_time ? formatDateTime(row.close_time) : null,
-          drink_last_order_time: row.drink_last_order_time ? formatDateTime(row.drink_last_order_time) : null,
-          food_last_order_time: row.food_last_order_time ? formatDateTime(row.food_last_order_time) : null,
-          happy_hour_start: row.happy_hour_start ? formatDateTime(row.happy_hour_start) : null,
-          happy_hour_end: row.happy_hour_end ? formatDateTime(row.happy_hour_end) : null,
-          created_at: now,
-          updated_at: now,
-        }))
-        .filter((h) => h.open_time && h.close_time)
-
-      if (hoursData.length > 0) {
-        await prisma.operatingHour.createMany({ data: hoursData })
-      }
-
-      console.log(`Upserted restaurant ${restaurantId} (${data.name}) with ${hoursData.length} operating hours`)
-    } catch (dbError) {
-      console.error(`Database error for restaurant ${restaurantId} (${rows[0].name}):`, dbError)
-    }
-  }
-
-  // CSVはrestaurant_idを明示して投入するため、autoincrementのシーケンスが
-  // 進まない。このままだと新規店舗の作成が既存IDと衝突して失敗するので、
-  // シーケンスを現在の最大IDに合わせる
-  await prisma.$executeRawUnsafe(
-    `SELECT setval(pg_get_serial_sequence('"Restaurant"', 'restaurant_id'), (SELECT COALESCE(MAX(restaurant_id), 1) FROM "Restaurant"))`
-  )
-  console.log('Restaurant id sequence synced')
-
-  console.log('Seeding completed successfully')
 }
 
 main()


### PR DESCRIPTION
## 概要

本番DBへ手元から直接接続しなくても、Basic認証付きのエンドポイント（`/api/admin/seed`）をブラウザで開くだけで`data/restaurants.csv`の内容を本番DBに反映できるようにします。今後CSVを更新してデプロイするたびに再利用できる運用導線です。

- `lib/seedRestaurants.js`: seedロジックをCLI（`prisma/seed.js`）とAPIの共通モジュールに切り出し（IDシーケンス同期を含む）
- `app/api/admin/seed/route.js`: GET/POSTでseedを実行し結果サマリをJSONで返す。`/api/admin`配下はmiddlewareで常にBasic認証必須。Vercelのタイムアウト対策で`maxDuration=60`
- `next.config.mjs`: サーバーレス関数のバンドルに`data/restaurants.csv`が含まれるよう`outputFileTracingIncludes`を設定

## 検証

ローカルで認証なし401・認証ありで79店舗upsert＋シーケンス同期の成功、CLI版seedの動作継続、本番ビルド（`npm run build`）の成功を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDJtiGt9WuuispTsE2YHUt

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDJtiGt9WuuispTsE2YHUt)_